### PR TITLE
Add firewall rules for nfs

### DIFF
--- a/lab_setup/repo/nfs_setup.md
+++ b/lab_setup/repo/nfs_setup.md
@@ -36,3 +36,6 @@ chown -R 1015:1015 /export/home/cindy
 
 ## 6. Restart NFS
 `systemctl restart nfs-server`
+
+## 7. Add firewall rules
+`firewall-cmd --permanent --add-service=nfs --add-service=mountd --add-service=rpc-bind`


### PR DESCRIPTION
Without this rules autofs doesn't work on server1 and server2 if firewalld is running.