### PR TITLE
Added SELinux boolean to allow NFS home directories

### DIFF
--- a/exam_prep/solutions_ordered_task_list.md
+++ b/exam_prep/solutions_ordered_task_list.md
@@ -139,6 +139,9 @@ mkdir /mnt/autofs_home
 ### Create and add the following to /etc/auto.home:
 * 192.168.55.47:/export/home/&
 
+### Set SELinux boolean to allow for NFS home directories ###
+setsebool -P use_nfs_home_dirs on
+
 systemctl restart autofs
 ```
 


### PR DESCRIPTION
Enabled "use_nfs_home_dirs"

Otherwise, NFS mounted home directories will not receive the "user_home_dir_t" SELinux context type. User will receive an error when initiating a user session (not through su -) and will be left in the root directory. Not sure if this is necessary for the exam or not.